### PR TITLE
fix(agent-runner): reset turnExpectsReply per follow-up batch

### DIFF
--- a/container/agent-runner/src/poll-loop.test.ts
+++ b/container/agent-runner/src/poll-loop.test.ts
@@ -539,6 +539,36 @@ describe('silent-turn recovery', () => {
     expect(out).toHaveLength(1);
     expect(calls).toBe(1); // replied first time — no nudge
   });
+
+  it('does not nudge a task follow-up that lands after a completed chat turn', async () => {
+    seedWaDestination();
+    insertMessage('m1', 'chat', { sender: 'John', text: 'Hoi' });
+    const messages = getPendingMessages();
+    const routing = extractRouting(messages);
+    const { markProcessing } = await import('./db/messages-in.js');
+    markProcessing(['m1']);
+
+    let calls = 0;
+    const provider = new MockProvider({}, () => {
+      calls++;
+      if (calls === 1) {
+        // Between turn 1 and turn 2, drop in a silent task follow-up. It gets
+        // picked up by the follow-up poll (ACTIVE_POLL_INTERVAL_MS = 500ms), so
+        // the query has to stay open past one poll tick.
+        setTimeout(() => insertMessage('t1', 'task', { prompt: 'silent task' }), 20);
+        return '<message to="wa">Hoi terug!</message>';
+      }
+      return ''; // task turn stays silent — intentional per task spec
+    });
+    const query = provider.query({ prompt: 'Hoi', cwd: '/tmp' });
+    setTimeout(() => query.end(), 900);
+
+    await processQuery(query, routing, ['m1'], 'mock', undefined, 'Hoi', undefined, false, true);
+
+    const out = getUndeliveredMessages();
+    expect(out).toHaveLength(1); // only the chat reply
+    expect(calls).toBe(2); // chat reply + one silent task turn, no nudge
+  });
 });
 
 describe('isCorruptionError', () => {

--- a/container/agent-runner/src/poll-loop.ts
+++ b/container/agent-runner/src/poll-loop.ts
@@ -455,11 +455,13 @@ export async function processQuery(
         const prompt = formatMessages(keep);
         log(`Pushing ${keep.length} follow-up message(s) into active query`);
         unwrappedNudged = false;
-        // Fresh user input gets a fresh shot at silent-turn recovery: re-arm
-        // the nudge and (re)mark this run as reply-expecting if the follow-up
-        // is conversational.
+        // Fresh user input gets a fresh shot at silent-turn recovery. Rebind
+        // the reply expectation to THIS batch — a chat follow-up sets it true,
+        // a task-only follow-up sets it false. Latching to true forever caused
+        // task ticks that follow a chat to trigger the silent-turn nudge and
+        // forced background tasks to emit an extra channel message.
         silentNudgeStreak = 0;
-        if (expectsReply(keep)) turnExpectsReply = true;
+        turnExpectsReply = expectsReply(keep);
         query.push(prompt);
         archivePrompts.push(prompt);
         // Follow-up images: same pattern as the initial batch — separate

--- a/docs/operational-gotchas.md
+++ b/docs/operational-gotchas.md
@@ -256,3 +256,26 @@ entries with `[migration-only]` so they're easy to prune later.
       addressed to its channel/sender lands, otherwise re-prompt
       specifically for the unanswered message. Bigger change to the batching
       model than the nudge; do this only if the hardened nudge still leaks.
+
+33. **Silent-turn nudge fired on task ticks that followed a chat**
+    (fixed 2026-07-02, `container/agent-runner/src/poll-loop.ts`). The nudge
+    (item 32) is gated on a `turnExpectsReply` flag. That flag was **set
+    only, never cleared** — the initial chat batch latched it to `true` and
+    it stayed true for the rest of the `processQuery` run. So when a
+    scheduled task fired *later* in the same run (a follow-up `query.push()`
+    into the still-open query, `poll-loop.ts` ~433) and ended silently — as
+    routine-success tasks are documented to — the nudge still fired and
+    forced the background task to emit an extra channel message, violating
+    the "silent on routine success" task contract. Fix: rebind the flag to
+    the current follow-up batch instead of latching —
+    `turnExpectsReply = expectsReply(keep)` (was
+    `if (expectsReply(keep)) turnExpectsReply = true`). A chat follow-up sets
+    it true, a task-only follow-up sets it false. `initialExpectsReply` and
+    the `expectsReply` predicate are untouched. Tradeoff (rare, not
+    addressed): if a task follow-up lands *before* an as-yet-undelivered
+    chat's turn-end fires, the flag clears and that chat's silent-turn nudge
+    is suppressed — in practice the chat's end-of-turn fires first. Regression
+    test: `poll-loop.test.ts` "does not nudge a task follow-up that lands
+    after a completed chat turn" (silent-turn recovery block is now ×5).
+    Deploys on the next container cold-start via the live bind-mount (item
+    32 "Deployment") — no image rebuild or host restart required.

--- a/journal/260702-fix-silent-turn-nudge-on-task-after-chat.md
+++ b/journal/260702-fix-silent-turn-nudge-on-task-after-chat.md
@@ -1,0 +1,86 @@
+# Reset `turnExpectsReply` per follow-up batch — stop silent-turn nudge firing on task ticks
+
+**Date:** 2026-07-02
+**Area:** `container/agent-runner/src/poll-loop.ts` (silent-turn recovery)
+**PR:** [#734](https://github.com/johnmathews/nanoclaw/pull/734) — branch `fix/reset-turn-expects-reply-per-batch`
+
+## What was wrong
+
+The silent-turn recovery mechanism (added 2026-06-23, documented in
+`docs/operational-gotchas.md` item 32) injects a one-shot `<system>Delivery
+check…</system>` nudge when a turn triggered by a user chat message delivers
+nothing, so the model can recover a dropped reply. Correct for chat turns.
+
+The nudge is gated on a `turnExpectsReply` flag. That flag was **set only,
+never cleared**: the initial chat batch latched it to `true` and it stayed
+true for the whole `processQuery` run. The follow-up handler read:
+
+```ts
+silentNudgeStreak = 0;
+if (expectsReply(keep)) turnExpectsReply = true;   // latch — never sets false
+```
+
+**Symptom in the wild.** A group's scheduled task (e.g. a 15-min
+"library-forward" email sweep) is documented to stay silent on the channel on
+routine success. That works when the task fires cold. But if any chat message
+arrived earlier in the same `processQuery` run, `turnExpectsReply` was latched
+true — so when the task-fire turn ended silently, the nudge fired and forced
+the background task to emit an extra channel message. Exactly the
+"silent on routine success" contract, violated.
+
+## The fix
+
+Rebind the flag to the current follow-up batch instead of latching:
+
+```ts
+silentNudgeStreak = 0;
+turnExpectsReply = expectsReply(keep);
+```
+
+A chat follow-up sets it true; a task-only follow-up sets it false. Blast
+radius kept to the one line — `initialExpectsReply` handling in the caller and
+the `expectsReply` predicate are untouched.
+
+### Tradeoff (noted, not addressed)
+
+If a chat message arrives, its reply hasn't been delivered yet, and a task
+follow-up lands in the same run *before* the chat's turn-end fires, the flag
+clears and the chat's silent-turn nudge is suppressed. In practice this is
+rare — the chat's end-of-turn event and its nudge normally fire before any
+follow-up is picked up. If it ever bites, the follow-up is a
+"delivered-since-last-chat" tracker; not needed today.
+
+## Test
+
+Added `does not nudge a task follow-up that lands after a completed chat turn`
+to the `silent-turn recovery` block (now ×5). It drives a chat turn that
+replies, drops a silent task follow-up into the still-open query mid-run, and
+asserts only the chat reply is delivered and no nudge fires.
+
+One deviation from the original test sketch: the query-end timing was bumped
+200ms → 900ms. The follow-up poll only runs every `ACTIVE_POLL_INTERVAL_MS`
+(500ms); at 200ms the task was never polled into the query, so the follow-up
+path wasn't exercised and the test recorded 1 model call instead of 2. At
+900ms it genuinely pushes the follow-up (log: "Pushing 1 follow-up message(s)")
+and the assertion holds. It's a real regression guard — with the old latching
+code, turn 2 still sees `turnExpectsReply=true` → nudge → 3 model calls.
+
+## Verification & deploy
+
+- `bun test src/poll-loop.test.ts` → 38 pass / 0 fail (all 4 pre-existing
+  silent-turn tests + the new one).
+- Container typecheck clean (`tsc -p container/agent-runner/tsconfig.json`).
+- Deploy: agent-runner `src/` is **bind-mounted live** (read-only) into
+  `/app/src` (`src/container-runner.ts:344`; containers run
+  `bun run /app/src/index.ts` with no baked image), so the fix applies on the
+  next container **cold-start** — no image rebuild or host restart required.
+  I did rebuild the image and restart the service during the session before
+  re-reading the deployment note; harmless, and the running container
+  (cold-started after the restart) is already on the fixed source.
+
+## Housekeeping (same session)
+
+Reclaimed ~10 GB on the LXC (88% → 61% root usage): pruned 8 dangling Docker
+images (old agent builds) + unused build cache + 2 orphaned anonymous volumes.
+Left tagged images belonging to other services and the named
+`apps_syncthing_config` volume untouched.


### PR DESCRIPTION
## Problem

The silent-turn recovery nudge in `container/agent-runner/src/poll-loop.ts` is gated on `turnExpectsReply`. That flag was **set only, never cleared** — the initial chat batch latched it to `true` and it stayed true for the rest of the `processQuery` run:

```ts
silentNudgeStreak = 0;
if (expectsReply(keep)) turnExpectsReply = true;  // latch
```

**Symptom:** a group's scheduled task (e.g. a 15-min "library-forward" email sweep) is documented to stay silent on the channel on routine success. That works when the task fires cold. But if any chat message arrives earlier in the same `processQuery` run, `turnExpectsReply` latches to true — so when the task-fire turn ends silently, the nudge (`<system>Delivery check…</system>`) injects and the agent is forced to emit an extra channel message, violating the "silent on routine success" task contract.

## Fix

Rebind `turnExpectsReply` to the current follow-up batch instead of latching:

```ts
silentNudgeStreak = 0;
turnExpectsReply = expectsReply(keep);
```

A chat follow-up sets it true; a task-only follow-up sets it false. `initialExpectsReply` handling and the `expectsReply` predicate are untouched.

## Tradeoff (noted, not addressed)

If a chat message arrives, its reply hasn't been delivered yet, and a task follow-up lands in the same run *before* the chat's turn-end fires, the flag clears and the chat's silent-turn nudge is suppressed. In practice this is rare — the chat's end-of-turn event and its nudge normally fire before any follow-up is picked up. If it becomes a real problem, layer on a "delivered-since-last-chat" tracker later.

## Test

Adds `does not nudge a task follow-up that lands after a completed chat turn` to the `silent-turn recovery` block. With the old latching code this test fails (turn 2 sees `turnExpectsReply=true` → nudge → 3 model calls); with the fix it passes (2 calls, only the chat reply delivered). All 38 agent-runner poll-loop tests pass; container typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0146rRnLCiWgPJiyZ3MW81Jm