### PR TITLE
fix(agent-runner): match rate_limit_event as a top-level SDK message type

### DIFF
--- a/container/agent-runner/src/providers/claude.events.test.ts
+++ b/container/agent-runner/src/providers/claude.events.test.ts
@@ -1,0 +1,73 @@
+/**
+ * Regression coverage for ClaudeProvider's SDK-message → ProviderEvent mapping.
+ *
+ * Focus: `@anthropic-ai/claude-agent-sdk` 0.3.x ships rate limits as a
+ * top-level `SDKRateLimitEvent` (`{ type: 'rate_limit_event' }`), NOT as a
+ * `system` message with `subtype: 'rate_limit_event'`. The provider used to
+ * match the old shape, so the branch was dead and quota signals were dropped
+ * entirely. These tests lock in the top-level match.
+ *
+ * The SDK is stubbed so the mapping can be driven deterministically — no real
+ * model call, no timers, no flakiness.
+ */
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+
+let sdkMessages: Array<Record<string, unknown>> = [];
+
+mock.module('@anthropic-ai/claude-agent-sdk', () => ({
+  query: () =>
+    (async function* () {
+      for (const m of sdkMessages) yield m;
+    })(),
+}));
+
+const { ClaudeProvider } = await import('./claude.js');
+
+async function collectEvents(): Promise<Array<{ type: string; [k: string]: unknown }>> {
+  const provider = new ClaudeProvider();
+  const out: Array<{ type: string; [k: string]: unknown }> = [];
+  for await (const e of provider.query({ prompt: 'hi', cwd: '/tmp' }).events) {
+    out.push(e as { type: string; [k: string]: unknown });
+  }
+  return out;
+}
+
+describe('ClaudeProvider — SDK event mapping', () => {
+  beforeEach(() => {
+    sdkMessages = [];
+  });
+
+  it('maps a top-level rate_limit_event to a non-retryable quota error', async () => {
+    sdkMessages = [
+      { type: 'system', subtype: 'init', session_id: 's1' },
+      { type: 'rate_limit_event' }, // SDKRateLimitEvent — no `system` subtype
+      { type: 'result', subtype: 'success', result: 'done' },
+    ];
+
+    const events = await collectEvents();
+    const err = events.find((e) => e.type === 'error');
+
+    expect(err).toBeDefined();
+    expect(err).toMatchObject({
+      type: 'error',
+      message: 'Rate limit',
+      retryable: false,
+      classification: 'quota',
+    });
+  });
+
+  it('does not treat the legacy system-subtype shape as a rate limit (guards the fix)', async () => {
+    // The shape the SDK no longer sends; the old dead branch matched this.
+    sdkMessages = [
+      { type: 'system', subtype: 'init', session_id: 's2' },
+      { type: 'system', subtype: 'rate_limit_event' },
+      { type: 'result', subtype: 'success', result: 'done' },
+    ];
+
+    const events = await collectEvents();
+
+    expect(events.find((e) => e.type === 'error')).toBeUndefined();
+    // The turn still completes normally.
+    expect(events.find((e) => e.type === 'result')).toMatchObject({ type: 'result', text: 'done' });
+  });
+});

--- a/container/agent-runner/src/providers/claude.ts
+++ b/container/agent-runner/src/providers/claude.ts
@@ -474,7 +474,10 @@ export class ClaudeProvider implements AgentProvider {
           yield { type: 'result', text, isError: m.is_error === true };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'api_retry') {
           yield { type: 'error', message: 'API retry', retryable: true };
-        } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'rate_limit_event') {
+        } else if (message.type === 'rate_limit_event') {
+          // SDK 0.3.x ships this as a top-level message type (SDKRateLimitEvent),
+          // not a `system` subtype — matching the old shape here left this branch
+          // dead and dropped the quota signal entirely.
           yield { type: 'error', message: 'Rate limit', retryable: false, classification: 'quota' };
         } else if (message.type === 'system' && (message as { subtype?: string }).subtype === 'compact_boundary') {
           const meta = (message as { compact_metadata?: { pre_tokens?: number } }).compact_metadata;


### PR DESCRIPTION
Cherry-pick of upstream `e8a32207` (nanocoai/nanoclaw) + a regression test.

## What

`@anthropic-ai/claude-agent-sdk` 0.3.x ships rate limits as a top-level `SDKRateLimitEvent` (`{ type: 'rate_limit_event' }`), not as a `system` message with `subtype: 'rate_limit_event'`. The provider matched the old shape, so the branch was dead and quota signals were silently dropped. Matches the top-level `type` instead.

## Added on top of the cherry-pick

`claude.events.test.ts` — a deterministic regression test that stubs the SDK and drives `ClaudeProvider`'s message→event mapping, asserting a top-level `rate_limit_event` yields a non-retryable `classification: 'quota'` error (and that the obsolete subtype shape no longer does). No model call, no timers.

## CI note

CI will show the pre-existing `/clear` + `silent-turn` full-suite failures (cross-file session-DB pollution, tracked in #735) — both fail on `main` and are unrelated to this change. The new test passes and does not leak its SDK mock into sibling files (full suite: 162 pass / 2 known-pre-existing fail).

🤖 Generated with [Claude Code](https://claude.com/claude-code)