### PR TITLE
test(upload-trace): fix cross-file DB pollution (pass abort signal into runPollLoop)

### DIFF
--- a/container/agent-runner/src/upload-trace.test.ts
+++ b/container/agent-runner/src/upload-trace.test.ts
@@ -67,7 +67,12 @@ describe('poll loop — /upload-trace command', () => {
 
 async function runPollLoopWithTimeout(provider: MockProvider, signal: AbortSignal, timeoutMs: number): Promise<void> {
   return Promise.race([
-    runPollLoop({ provider, providerName: 'mock', cwd: '/tmp' }),
+    // The signal MUST be threaded into runPollLoop — without it the loop's
+    // `signal?.aborted` check never fires, so controller.abort() only settles
+    // the race while the real loop runs forever, polling the shared session DB
+    // into every later test file and stealing their pending messages. This was
+    // the source of the cross-file "unable to open database file" pollution.
+    runPollLoop({ provider, providerName: 'mock', cwd: '/tmp', signal }),
     new Promise<void>((_, reject) => {
       signal.addEventListener('abort', () => reject(new Error('aborted')));
     }),


### PR DESCRIPTION
Closes #735.

## Root cause

`upload-trace.test.ts`'s local `runPollLoopWithTimeout` helper called `runPollLoop({ provider, providerName, cwd })` **without `signal`** — unlike the identical helper in `integration.test.ts`. With no signal, `runPollLoop`'s `config.signal?.aborted` check never fires, so `controller.abort()` only settles the wrapping `Promise.race` while the underlying loop **runs forever**: polling the shared global session DB every second into every later test file, `markProcessing`-ing their pending messages (stealing them), and throwing `unable to open database file` right after each `closeSessionDb()`.

This is precisely what the `PollLoopConfig.signal` doc comment warns about ("an abandoned loop … polling forever and stealing messages from the next test's DB").

## Impact

It made the full `bun test` run **deterministically red on two unrelated tests** — `integration › /clear arrives as a follow-up` and `poll-loop › silent-turn › does not nudge a task follow-up` — both of which pass in isolation. That's the ~3 weeks of red CI on every container-touching PR (#734, #737, both #2828 branches), which had to be `--admin`-merged.

## Fix

One line: thread `signal` through, matching `integration.test.ts`. No production code change (`poll-loop.ts` untouched; prod never passes a signal anyway).

## Verification

16 consecutive full-suite runs, **164 pass / 0 fail** each. Bisected the polluter (`upload-trace.test.ts` before the victims reproduces; alone all files pass). This PR's own CI should be the first **green** code-PR run in weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)